### PR TITLE
Allow attaching a permission boundary to a Permission Set

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ A Terraform module which helps you create permissions-sets. Read [this](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    })<br>  }))</pre> | n/a | yes |
+| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = optional(object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    }))<br>  }))</pre> | n/a | yes |
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,14 @@ A Terraform module which helps you create permissions-sets. Read [this](https://
 | [aws_ssoadmin_managed_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
 | [aws_ssoadmin_permission_set_inline_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
+| [aws_ssoadmin_permissions_boundary_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permissions_boundary_attachment) | resource |
 | [aws_ssoadmin_instances.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>  }))</pre> | n/a | yes |
+| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    })<br>  }))</pre> | n/a | yes |
 
 ### Outputs
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -46,7 +46,8 @@ module "permission_sets" {
       tags                                = {},
       inline_policy                       = "",
       customer_managed_policy_attachments = [],
-      policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"]
+      policy_attachments                  = ["arn:aws:iam::aws:policy/AdministratorAccess"],
+      permissions_boundary_attachment     = []
     },
   ]
 }

--- a/modules/permission-sets/README.md
+++ b/modules/permission-sets/README.md
@@ -1,4 +1,3 @@
-<!-- BEGIN_TF_DOCS -->
 ## Permission sets
 A Terraform module which helps you create permissions-sets. Read [this](https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html) page for more information.
 
@@ -23,17 +22,17 @@ A Terraform module which helps you create permissions-sets. Read [this](https://
 | [aws_ssoadmin_managed_policy_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_managed_policy_attachment) | resource |
 | [aws_ssoadmin_permission_set.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set) | resource |
 | [aws_ssoadmin_permission_set_inline_policy.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permission_set_inline_policy) | resource |
+| [aws_ssoadmin_permissions_boundary_attachment.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ssoadmin_permissions_boundary_attachment) | resource |
 | [aws_ssoadmin_instances.default](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ssoadmin_instances) | data source |
 
 ### Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>  }))</pre> | n/a | yes |
+| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    })<br>  }))</pre> | n/a | yes |
 
 ### Outputs
 
 | Name | Description |
 |------|-------------|
 | <a name="output_permission_sets"></a> [permission\_sets](#output\_permission\_sets) | The created permission-sets |
-<!-- END_TF_DOCS -->

--- a/modules/permission-sets/README.md
+++ b/modules/permission-sets/README.md
@@ -29,7 +29,7 @@ A Terraform module which helps you create permissions-sets. Read [this](https://
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    })<br>  }))</pre> | n/a | yes |
+| <a name="input_permission_sets"></a> [permission\_sets](#input\_permission\_sets) | A list of permission-sets that you would like to create. | <pre>list(object({<br>    name               = string<br>    description        = string<br>    relay_state        = string<br>    session_duration   = string<br>    tags               = map(string)<br>    inline_policy      = string<br>    policy_attachments = list(string)<br>    customer_managed_policy_attachments = list(object({<br>      name = string<br>      path = string<br>    }))<br>    permissions_boundary_attachment = optional(object({<br>      name               = optional(string)<br>      path               = optional(string)<br>      managed_policy_arn = optional(string)<br>    }))<br>  }))</pre> | n/a | yes |
 
 ### Outputs
 

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -11,11 +11,11 @@ variable "permission_sets" {
       name = string
       path = string
     }))
-    permissions_boundary_attachment = object({
+    permissions_boundary_attachment = optional(object({
       name               = optional(string)
       path               = optional(string)
       managed_policy_arn = optional(string)
-    })
+    }))
   }))
   description = "A list of permission-sets that you would like to create."
 }

--- a/modules/permission-sets/variables.tf
+++ b/modules/permission-sets/variables.tf
@@ -11,6 +11,11 @@ variable "permission_sets" {
       name = string
       path = string
     }))
+    permissions_boundary_attachment = object({
+      name               = optional(string)
+      path               = optional(string)
+      managed_policy_arn = optional(string)
+    })
   }))
   description = "A list of permission-sets that you would like to create."
 }


### PR DESCRIPTION
## What
- Created  an `aws_ssoadmin_permissions_boundary_attachment` resource.
- Added  `permissions_boundary_attachment`  inside `var.permission_sets`
- Updated README.md files at root and module level.

## Why
The module didn't have the capability to attach a Permission Boundary to a Permission Set.
