### PR TITLE
Fixed customer managed policy attachment

### DIFF
--- a/modules/permission-sets/main.tf
+++ b/modules/permission-sets/main.tf
@@ -54,7 +54,7 @@ resource "aws_ssoadmin_customer_managed_policy_attachment" "default" {
     for customer_managed_policy_attachment in local.customer_managed_policy_attachments : "${customer_managed_policy_attachment.name}-${customer_managed_policy_attachment.customer_managed_policy_attachment.path}${customer_managed_policy_attachment.customer_managed_policy_attachment.name}" => customer_managed_policy_attachment
   }
   instance_arn       = local.instance_arn
-  permission_set_arn = aws_ssoadmin_permission_set.default[each.value.policy_set].arn
+  permission_set_arn = aws_ssoadmin_permission_set.default[each.value.name].arn
 
   customer_managed_policy_reference {
     name = each.value.customer_managed_policy_attachment.name


### PR DESCRIPTION
## What
- Changed the key value used to access the Permission Set ARN in the aws_ssoadmin_customer_managed_policy_attachment resource

## Why
Terraform generated the following error because `policy_set` is not a valid key:
```
│ Error: Unsupported attribute
│
│   on .terraform/modules/ic_permission_sets/modules/permission-sets/main.tf line 57, in resource "aws_ssoadmin_customer_managed_policy_attachment" "default":
│   57:   permission_set_arn = aws_ssoadmin_permission_set.default[each.value.policy_set].arn
│     ├────────────────
│     │ each.value is object with 10 attributes
│
│ This object does not have an attribute named "policy_set".
```

After the proposed change, Terraform generates this new output:
```
  # module.ic_permission_sets["A-PermissionSet"].aws_ssoadmin_managed_policy_attachment.default["A-PermissionSet-arn:aws:iam::aws:policy/AmazonAthenaFullAccess"] will be created
  + resource "aws_ssoadmin_managed_policy_attachment" "default" {
      + id                  = (known after apply)
      + instance_arn        = "arn:aws:sso:::instance/ssoins-xxxxxx"
      + managed_policy_arn  = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
      + managed_policy_name = (known after apply)
      + permission_set_arn  = (known after apply)
    }
```
