### PR TITLE
feat!: require AWS provider v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    if: github.event.pull_request.state == 'open'
+    runs-on: ubuntu-latest
+    container: blackbirdcloud/terraform-toolkit:latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Terraform test
+        env:
+          TFENV_TERRAFORM_VERSION: latest-allowed
+        run: |
+          terraform init -backend=false
+          terraform test

--- a/.template-version
+++ b/.template-version
@@ -1,2 +1,2 @@
 template: terraform-module-template
-version: v1.2.0
+version: v1.3.0

--- a/example/versions.tf
+++ b/example/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.2"

--- a/modules/account-assignments/versions.tf
+++ b/modules/account-assignments/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.2"

--- a/modules/permission-sets/versions.tf
+++ b/modules/permission-sets/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5"
+      version = "~> 6.0"
     }
   }
   required_version = ">= 1.2"

--- a/tests/main.tftest.hcl
+++ b/tests/main.tftest.hcl
@@ -1,0 +1,53 @@
+mock_provider "aws" {
+  mock_data "aws_identitystore_group" {
+    defaults = {
+      id = "12345678-1234-1234-1234-123456789012"
+    }
+  }
+  mock_data "aws_identitystore_user" {
+    defaults = {
+      id = "12345678-1234-1234-1234-123456789012"
+    }
+  }
+  mock_data "aws_ssoadmin_instances" {
+    defaults = {
+      arns               = ["arn:aws:sso:::instance/ssoins-1111111111111111"]
+      identity_store_ids = ["d-1234567890"]
+    }
+  }
+}
+
+run "permission_sets" {
+  command = plan
+  module {
+    source = "./modules/permission-sets"
+  }
+  variables {
+    permission_sets = [{
+      name                                = "TestAdmin"
+      description                         = "Test permission set"
+      relay_state                         = ""
+      session_duration                    = "PT8H"
+      tags                                = {}
+      inline_policy                       = ""
+      policy_attachments                  = []
+      customer_managed_policy_attachments = []
+    }]
+  }
+}
+
+run "account_assignments" {
+  command = plan
+  module {
+    source = "./modules/account-assignments"
+  }
+  variables {
+    account_assignments = [{
+      account             = "123456789012"
+      permission_set_name = "TestAdmin"
+      permission_set_arn  = "arn:aws:sso:::permissionSet/ssoins-1111111111111111/ps-1111111111111111"
+      principal_name      = "test-group"
+      principal_type      = "GROUP"
+    }]
+  }
+}


### PR DESCRIPTION
## What
Requires **AWS provider v6** (`~> 6.0`) in the module (root, submodules, and example).

## Why
Org-wide provider modernization: the newest modules (backup, organization) are already on `~> 6.0`; this sweep brings the rest of the template-aligned fleet to the same bounded constraint. Two-component `~>` is used deliberately — single-component constraints (`~> 5`) have no upper bound.

`terraform init` + `terraform validate` pass against the latest AWS provider 6.x for the root module and all submodules.

## Breaking change
Consumers still on AWS provider 4/5 must stay on the previous module major. This PR carries the `release:major` label so the release automation bumps the major version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)